### PR TITLE
Improving Creality cr4ntxxC10

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -724,7 +724,7 @@
 #elif MB(CREALITY_V24S1_301F4)
   #include "stm32f4/pins_CREALITY_V24S1_301F4.h" // STM32F4                               env:STM32F401RC_creality env:STM32F401RC_creality_jlink env:STM32F401RC_creality_stlink
 #elif MB(CREALITY_CR4NTxxC10)
-  #include "stm32f4/pins_CREALITY_CR4NTxxC10.h" // STM32F4                                env:STM32F401RE_creality env:STM32F401RE_creality_jlink env:STM32F401RE_creality_stlink
+  #include "stm32f4/pins_CREALITY_CR4NTxxC10.h" // STM32F4                                env:STM32F401RC_creality env:STM32F401RC_creality_jlink env:STM32F401RC_creality_stlink env:STM32F401RE_creality env:STM32F401RE_creality_jlink env:STM32F401RE_creality_stlink
 #elif MB(OPULO_LUMEN_REV4)
   #include "stm32f4/pins_OPULO_LUMEN_REV4.h"    // STM32F4                                env:Opulo_Lumen_REV4
 #elif MB(FYSETC_SPIDER_KING407)

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTxxC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTxxC10.h
@@ -63,7 +63,7 @@
 //
 // Servos
 //
-#define SERVO0_PIN                          PB1   // BLTouch PWM-OUT PIN (TOUCH pins in the schematic have changed)
+#define SERVO0_PIN                          PB0   // BLTouch PWM-OUT PIN (TOUCH pins in the schematic have changed)
 
 //
 // Limit Switches
@@ -72,14 +72,14 @@
 #define Y_STOP_PIN                          PA6
 
 #if ENABLED(BLTOUCH)
-  #define Z_MIN_PIN                         PB0   // BLTouch IN PIN (TOUCH pins in the schematic have changed)
+  #define Z_MIN_PIN                         PB1   // BLTouch IN PIN (TOUCH pins in the schematic have changed)
   #define Z_MAX_PIN                         PA7
 #else
   #define Z_STOP_PIN                        PA7   // Z-axis limit switch
 #endif
 
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN                   PB0   // BLTouch IN
+  #define Z_MIN_PROBE_PIN                   PB1   // BLTouch IN
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTxxC10.h
+++ b/Marlin/src/pins/stm32f4/pins_CREALITY_CR4NTxxC10.h
@@ -189,6 +189,10 @@
 #define SDIO_SUPPORT
 #define NO_SD_HOST_DRIVE                  // This board's SD is only seen by the printer
 
+#if !AXIS_DRIVER_TYPE_X(TMC2209) || !AXIS_DRIVER_TYPE_Y(TMC2209) || !AXIS_DRIVER_TYPE_Z(TMC2209) || !AXIS_DRIVER_TYPE_E0(TMC2209)
+  #error "This board have soldered TMC2209 drivers for X,Y,Z,E0"
+#endif
+
 #if ENABLED(CR10_STOCKDISPLAY) && NONE(RET6_12864_LCD, VET6_12864_LCD)
   #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the Creality V4 controller."
 #endif

--- a/buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RE/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20080000;    /* end of RAM */
+_estack = 0x20018000;    /* end of RAM */
 
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;;      /* required amount of heap  */

--- a/buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RE/ldscript.ld
@@ -52,7 +52,7 @@
 ENTRY(Reset_Handler)
 
 /* Highest address of the user mode stack */
-_estack = 0x20018000;    /* end of RAM */
+_estack = 0x20017FFB;    /* end of RAM */
 
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x200;;      /* required amount of heap  */

--- a/buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RE/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_CREALITY_STM32F401RE/variant.h
@@ -102,6 +102,7 @@ extern "C" {
 // UART Definitions
 //#define ENABLE_HWSERIAL1        done automatically by the #define SERIAL_UART_INSTANCE below
 #define ENABLE_HWSERIAL2
+#define ENABLE_HWSERIAL6
 
 
 // Define here Serial instance number to map on Serial generic name (if not already used by SerialUSB)
@@ -119,6 +120,8 @@ extern "C" {
 #define PIN_SERIAL1_TX          PA9
 #define PIN_SERIAL2_RX          PA3
 #define PIN_SERIAL2_TX          PA2
+#define PIN_SERIAL6_RX          PC7
+#define PIN_SERIAL6_TX          PC6
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

- Fixed the Pinout for the BL-Touch which Creality messed up themselves
- Added the Serial6 that this board has and uses for comunication with its steppers
- Adding build option for STM32F401 **RE** and **RC**
- Adding error message that tells you when you've configured diffrent stepers then the ones soldered onto the board
- Fixing defined Stack size to be 96kb instead of 512kb for RE variant